### PR TITLE
Update README.md link to PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <br><br><br>
 Live page: [(click here!) https://marcuswilliamson.github.io/Switch2CompatTracker/](https://marcuswilliamson.github.io/Switch2CompatTracker/)
 
-This page scrapes the Nintendo eShop for compatibility information on the games listed in the PDFs here: [https://www.nintendo.com/us/gaming-systems/switch-2/transfer-guide/compatible-games/](https://www.nintendo.com/us/gaming-systems/switch-2/transfer-guide/compatible-games/)
+This page scrapes the Nintendo eShop for compatibility information on the games listed in the PDFs here: [https://web.archive.org/web/20250830233828/https://www.nintendo.com/us/gaming-systems/switch-2/transfer-guide/compatible-games/](https://web.archive.org/web/20250830233828/https://www.nintendo.com/us/gaming-systems/switch-2/transfer-guide/compatible-games/)
 
 Updates twice daily using GitHub Actions. Written in Python, uses BeautifulSoup4 for web scraping and Jinja2 for writing to HTML.
 


### PR DESCRIPTION
Nintendo removed the PDFs from the linked page, in this PR is changed to wayback machine before nintendo removed the PDFs
